### PR TITLE
Add changelog, more missed fields and validate.

### DIFF
--- a/docs/changelog/127053.yaml
+++ b/docs/changelog/127053.yaml
@@ -1,0 +1,6 @@
+pr: 127053
+summary: Add missing fields to the Logstash Stack Monitoring Template
+area: Monitoring
+type: enhancement
+issues:
+  - 125499

--- a/x-pack/plugin/core/template-resources/src/main/resources/monitoring-logstash-mb.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/monitoring-logstash-mb.json
@@ -70,16 +70,20 @@
                     "logstash": {
                       "properties": {
                         "ephemeral_id": {
-                          "type": "keyword"
+                          "type": "keyword",
+                          "ignore_above": 1024
                         },
                         "host": {
-                          "type": "keyword"
+                          "type": "keyword",
+                          "ignore_above": 1024
                         },
                         "http_address": {
-                          "type": "keyword"
+                          "type": "keyword",
+                          "ignore_above": 1024
                         },
                         "name": {
-                          "type": "keyword"
+                          "type": "keyword",
+                          "ignore_above": 1024
                         },
                         "pipeline": {
                           "properties": {
@@ -95,7 +99,8 @@
                           "type": "boolean"
                         },
                         "status": {
-                          "type": "keyword"
+                          "type": "keyword",
+                          "ignore_above": 1024
                         },
                         "uuid": {
                           "ignore_above": 1024,
@@ -281,14 +286,16 @@
                                   "type": "long"
                                 },
                                 "control_group": {
-                                  "type": "keyword"
+                                  "type": "keyword",
+                                  "ignore_above": 1024
                                 }
                               }
                             },
                             "cpuacct": {
                               "properties": {
                                 "control_group": {
-                                  "type": "keyword"
+                                  "type": "keyword",
+                                  "ignore_above": 1024
                                 },
                                 "usage_nanos": {
                                   "type": "long"
@@ -376,10 +383,71 @@
                             "graph": {
                               "properties": {
                                 "vertices": {
-                                  "type": "object"
+                                  "type": "nested",
+                                  "properties": {
+                                    "config_name": {
+                                      "type": "keyword",
+                                      "ignore_above": 1024
+                                    },
+                                    "explicit_id": {
+                                      "type": "boolean"
+                                    },
+                                    "id": {
+                                      "type": "keyword",
+                                      "ignore_above": 1024
+                                    },
+                                    "meta": {
+                                      "properties": {
+                                        "source": {
+                                          "properties": {
+                                            "column": {
+                                              "type": "long"
+                                            },
+                                            "id": {
+                                              "type": "keyword",
+                                              "ignore_above": 1024
+                                            },
+                                            "line": {
+                                              "type": "long"
+                                            },
+                                            "protocol": {
+                                              "type": "keyword",
+                                              "ignore_above": 1024
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "plugin_type": {
+                                      "type": "keyword",
+                                      "ignore_above": 1024
+                                    },
+                                    "type": {
+                                      "type": "keyword",
+                                      "ignore_above": 1024
+                                    }
+                                  }
                                 },
                                 "edges": {
-                                  "type": "object"
+                                  "type": "nested",
+                                  "properties": {
+                                    "from": {
+                                      "type": "keyword",
+                                      "ignore_above": 1024
+                                    },
+                                    "id": {
+                                      "type": "keyword",
+                                      "ignore_above": 1024
+                                    },
+                                    "to": {
+                                      "type": "keyword",
+                                      "ignore_above": 1024
+                                    },
+                                    "type": {
+                                      "type": "keyword",
+                                      "ignore_above": 1024
+                                    }
+                                  }
                                 }
                               }
                             }
@@ -412,6 +480,14 @@
                       "ignore_above": 1024
                     }
                   }
+                }
+              }
+            },
+            "cluster": {
+              "properties": {
+                "id": {
+                  "type": "keyword",
+                  "ignore_above": 1024
                 }
               }
             }
@@ -628,12 +704,60 @@
         },
         "host": {
           "properties": {
-            "name": {
+            "architecture": {
+              "type": "keyword",
+              "ignore_above": 1024
+            },
+            "hostname": {
+              "type": "keyword",
+              "ignore_above": 1024
+            },
+            "id": {
               "type": "keyword",
               "ignore_above": 1024
             },
             "ip": {
               "type": "ip"
+            },
+            "mac": {
+              "type": "keyword",
+              "ignore_above": 1024
+            },
+            "name": {
+              "type": "keyword",
+              "ignore_above": 1024
+            },
+            "os": {
+              "properties": {
+                "build": {
+                  "type": "keyword",
+                  "ignore_above": 1024
+                },
+                "family": {
+                  "type": "keyword",
+                  "ignore_above": 1024
+                },
+                "kernel": {
+                  "type": "keyword",
+                  "ignore_above": 1024
+                },
+                "name": {
+                  "type": "keyword",
+                  "ignore_above": 1024
+                },
+                "platform": {
+                  "type": "keyword",
+                  "ignore_above": 1024
+                },
+                "type": {
+                  "type": "keyword",
+                  "ignore_above": 1024
+                },
+                "version": {
+                  "type": "keyword",
+                  "ignore_above": 1024
+                }
+              }
             }
           }
         },
@@ -674,19 +798,24 @@
         "agent": {
           "properties": {
             "ephemeral_id": {
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "id": {
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "name": {
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "type": {
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "version": {
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             }
           }
         }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
@@ -77,7 +77,7 @@ public class MonitoringTemplateRegistry extends IndexTemplateRegistry {
      * writes monitoring data in ECS format as of 8.0. These templates define the ECS schema as well as alias fields for the old monitoring
      * mappings that point to the corresponding ECS fields.
      */
-    public static final int STACK_MONITORING_REGISTRY_VERSION = 8_00_00_99 + 21;
+    public static final int STACK_MONITORING_REGISTRY_VERSION = 8_00_00_99 + 22;
     private static final String STACK_MONITORING_REGISTRY_VERSION_VARIABLE = "xpack.stack.monitoring.template.release.version";
     private static final String STACK_TEMPLATE_VERSION = "8";
     private static final String STACK_TEMPLATE_VERSION_VARIABLE = "xpack.stack.monitoring.template.version";


### PR DESCRIPTION
This PR adds followings on top of https://github.com/elastic/elasticsearch/pull/127053:
- more fields which appear when plugins used
- bumps up the template version
- changelog

Validated on my local, the view:
<img width="1918" height="890" alt="Screenshot 2025-10-02 at 11 49 54 AM" src="https://github.com/user-attachments/assets/e7f47216-eb07-48ec-9a67-d528fb29c9d9" />



- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
